### PR TITLE
[TASK] Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,31 +3,31 @@ name: Bug report
 about: Create a report to help us improve
 ---
 
-## Bug Report
+# Bug Report
 
-### Description
+## Description
 
 Please provide a clear and concise description of the bug.
 
-### Steps to Reproduce
+## Steps to Reproduce
 
 1. Step 1
 2. Step 2
 3. Step 3
 
-### Expected Behavior
+## Expected Behavior
 
 Please describe what you expected to happen.
 
-### Actual Behavior
+## Actual Behavior
 
 Please describe what actually happened.
 
-### Screenshots
+## Screenshots
 
 If applicable, add screenshots to help explain the problem.
 
-### Environment
+## Environment
 
 - Operating System: [e.g. Windows 10]
 - Browser: [e.g. Chrome, Firefox]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,6 +33,6 @@ If applicable, add screenshots to help explain the problem.
 - Browser: [e.g. Chrome, Firefox]
 - Version: [e.g. 1.0.0]
 
-### Additional Information
+## Additional Information
 
 Add any other relevant information about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+## Bug Report
+
+### Description
+
+Please provide a clear and concise description of the bug.
+
+### Steps to Reproduce
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+### Expected Behavior
+
+Please describe what you expected to happen.
+
+### Actual Behavior
+
+Please describe what actually happened.
+
+### Screenshots
+
+If applicable, add screenshots to help explain the problem.
+
+### Environment
+
+- Operating System: [e.g. Windows 10]
+- Browser: [e.g. Chrome, Firefox]
+- Version: [e.g. 1.0.0]
+
+### Additional Information
+
+Add any other relevant information about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
 ---
 
 # Bug Report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+# Feature Request
+
+## Description
+
+Please provide a clear and concise description of the feature you would like to request.
+
+## Motivation
+
+Explain why this feature is important and how it would benefit the project.
+
+## Proposed Solution
+
+Outline your proposed solution or any ideas you have for implementing this feature.
+
+## Additional Context
+
+Add any additional context or screenshots about the feature request here.
+
+## Checklist
+
+- [ ] I have searched for similar feature requests and confirmed that this is a new request.
+- [ ] I have provided a clear and concise description of the feature.
+- [ ] I have explained the motivation behind this feature request.
+- [ ] I have outlined a proposed solution or ideas for implementing this feature.
+- [ ] I have provided any additional context or screenshots if applicable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Add GitHub issue templates for bug report and feature request (#297)
-- Typo in scatterplot.js [#283](https://github.com/uiuc-ischool-accessible-computing-lab/maidr/issues/283)
 - Added some notes on manual testing
+
+### Fixed
+
+- Typo in scatterplot.js [#283](https://github.com/uiuc-ischool-accessible-computing-lab/maidr/issues/283)
 - Fixed typo in task1_bar_plot.html, correct CSS file now called
 - Fixed initial position out of range, #287
+
+### Changed
+
 - Updated documentation for all scripts
 
 ## [1.0.0] - 2023-11-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add GitHub issue templates for bug report and feature request (#297)
 - Typo in scatterplot.js [#283](https://github.com/uiuc-ischool-accessible-computing-lab/maidr/issues/283)
 - Added some notes on manual testing
 - Fixed typo in task1_bar_plot.html, correct CSS file now called


### PR DESCRIPTION
This pull request adds GitHub issue templates for bug reports and feature requests. The bug report template includes sections for describing the bug, steps to reproduce, expected behavior, actual behavior, screenshots, and additional information. The feature request template includes sections for describing the feature, providing motivation, proposing a solution, and adding additional context. This will help developers and maintainers create well-formed issues and encourage contributors to provide sufficient details.

Fixes #295