### PR TITLE
Add instruction on how to screenshot in GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,8 @@ Please describe what actually happened.
 ## Screenshots
 
 If applicable, add screenshots to help explain the problem.
+You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool:
+https://gifcap.dev
 
 ## Environment
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,8 @@
 
 ## Screenshots (if applicable)
 [Include any relevant screenshots or images to help visualize the changes.]
+You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool:
+https://gifcap.dev
 
 ## Checklist
 [Please select all applicable options.]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added instructions on how to take a screenshot in in GitHub bug report and pull request templates (#307).
+
 ### Fixed
 
 ### Changed


### PR DESCRIPTION
This pull request adds instructions on how to capture a screen using a browser-based tool called [gifcap.dev](https://gifcap.dev). This will help users who are not familiar with capturing screenshots to easily capture and share their screens. Fixes #306