### PR TITLE
Comment out GH template instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,8 +9,7 @@ assignees: ''
 # Bug Report
 
 ## Description
-
-Please provide a clear and concise description of the bug.
+<!-- Please provide a clear and concise description of the bug. -->
 
 ## Steps to Reproduce
 
@@ -19,25 +18,20 @@ Please provide a clear and concise description of the bug.
 3. Step 3
 
 ## Expected Behavior
-
-Please describe what you expected to happen.
+<!-- Please describe what you expected to happen. -->
 
 ## Actual Behavior
-
-Please describe what actually happened.
+<!-- Please describe what actually happened. -->
 
 ## Screenshots
-
-If applicable, add screenshots to help explain the problem.
-You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool:
-https://gifcap.dev
+<!-- If applicable, add screenshots to help explain the problem. -->
+<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
+<!-- https://gifcap.dev -->
 
 ## Environment
-
 - Operating System: [e.g. Windows 10]
 - Browser: [e.g. Chrome, Firefox]
 - Version: [e.g. 1.0.0]
 
 ## Additional Information
-
-Add any other relevant information about the problem here.
+<!-- Add any other relevant information about the problem here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,23 +2,22 @@
 # Pull Request
 
 ## Description
-[Provide a brief description of the changes made in this pull request.]
+<!-- Provide a brief description of the changes made in this pull request. -->
 
 ## Related Issues
-[Specify any related issues or tickets that this pull request addresses.]
+<!-- Specify any related issues or tickets that this pull request addresses. -->
 
 ## Changes Made
-[Describe the specific changes made in this pull request.]
+<!-- Describe the specific changes made in this pull request. -->
 
 ## Screenshots (if applicable)
-[Include any relevant screenshots or images to help visualize the changes.]
-You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool:
-https://gifcap.dev
+<!-- Include any relevant screenshots or images to help visualize the changes. -->
+<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
+<!-- https://gifcap.dev -->
 
 ## Checklist
-[Please select all applicable options.]
-
-[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
+<!-- Please select all applicable options. -->
+<!-- To select your options, please put an 'x' in the all boxes that apply. -->
 
 - [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
 - [ ] I have updated the [CHANGELOG](../CHANGELOG.md).
@@ -29,6 +28,5 @@ https://gifcap.dev
 - [ ] I have added appropriate unit tests, if applicable.
 
 ## Additional Notes
-[Add any additional notes or comments here.]
-
-[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)
+<!-- Add any additional notes or comments here. -->
+<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added instructions on how to take a screenshot in in GitHub bug report and pull request templates (#307).
 
 ### Fixed
 
+
 ### Changed
+
+
+### Chores
+
+- Added instructions on how to take a screenshot in in GitHub bug report and pull request templates (#307).
+- Commented out the instructions on GitHub templates so that users can keep it while adding new content (#308).
 
 
 ## [1.0.4] - 2023-11-30


### PR DESCRIPTION
This pull request comments out the GitHub template instructions in the bug_report.md and PULL_REQUEST_TEMPLATE.md files, allowing users to keep the instructions as comments while adding new content.

Fixes #305