### PR TITLE
Fixed #230, adding a menu option to switch assertive / polite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the ability to switch from assertive (default) to polite aria modes, in the help menu. [#230](https://github.com/uiuc-ischool-accessible-computing-lab/maidr/issues/230)
 
 ### Fixed
 
-
 ### Changed
-
 
 ### Chores
 
 - Added instructions on how to take a screenshot in in GitHub bug report and pull request templates (#307).
 - Commented out the instructions on GitHub templates so that users can keep it while adding new content (#308).
-
 
 ## [1.0.4] - 2023-11-30
 

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -101,6 +101,13 @@ class Control {
               display.changeChartLayer('up');
             }
           }
+
+          // Debugging.
+          // Because we destroy on blur, it's hard to debug, so here's throwaway code to put a breakpoint on
+          // todo: on publish, remove this
+          if (e.key == '-') {
+            let nothing = null;
+          }
         },
       ]);
     }


### PR DESCRIPTION
# Pull Request

## Description
Created a menu option to switch between aria-live assertive and polite

## Related Issues
#230 

## Changes Made
 - created html for the actual menu
 - threaded the data through to constants and localStorage
 - created an UpdateHtml function that changes aria-live attribute, called on page load and menu save

## Screenshots (if applicable)

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

