### PR TITLE
feat: Integrated level of skill into initial LLM prompt, pulling from a user setting

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -77,7 +77,6 @@ class Constants {
   playLLMWaitingSound = true;
 
   // LLM settings
-  hasChatLLM = true;
   LLMDebugMode = 0; // 0 = use real data, 1 = all fake, 2 = real data but no image
   authKey = null; // OpenAI authentication key, set in menu
   LLMmaxResponseTokens = 1000; // max tokens to send to LLM, 20 for testing, 1000 ish for real
@@ -406,11 +405,7 @@ class Menu {
                               }><label for="aria_mode_polite">Polite</label></p>
                               </fieldset></div>
                             <h5 class="modal-title">LLM Settings</h5>
-                              ${
-                                constants.hasChatLLM
-                                  ? '<p><input type="password" id="chatLLM_auth_key"> <label for="chatLLM_auth_key">OpenAI Authentication Key</label></p>'
-                                  : ''
-                              }
+                            <p><input type="password" id="chatLLM_auth_key"> <label for="chatLLM_auth_key">OpenAI Authentication Key</label></p>
                             <p>
                                 <select id="skill_level">
                                     <option value="basic">Basic</option>
@@ -1142,7 +1137,16 @@ class ChatLLM {
     //let img = await this.ConvertSVGtoImg(singleMaidr.id);
     let img = await this.ConvertSVGtoJPG(singleMaidr.id);
     //this.downloadJPEG(img, 'test.jpg'); // test download
-    let text = 'Describe this chart. Here is chart in png format';
+    let text = 'Describe this chart to a blind person';
+    if (constants.skillLevel) {
+      text +=
+        ' who has a ' +
+        constants.skillLevel +
+        ' understanding of statistical charts. ';
+    } else {
+      text += ' who has a basic understanding of statistical charts. ';
+    }
+    text += 'Here is chart in png format';
     if (singleMaidr) {
       text += ' and raw data in json format: \n';
       text += JSON.stringify(singleMaidr);

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -82,6 +82,7 @@ class Constants {
   authKey = null; // OpenAI authentication key, set in menu
   LLMmaxResponseTokens = 1000; // max tokens to send to LLM, 20 for testing, 1000 ish for real
   LLMDetail = 'high'; // low (default for testing, like 100 tokens) / high (default for real, like 1000 tokens)
+  skillLevel = 'basic'; // basic / intermediate / expert
 
   // user controls (not exposed to menu, with shortcuts usually)
   showDisplay = 1; // true / false
@@ -404,15 +405,24 @@ class Menu {
                                 constants.ariaMode == 'polite' ? 'checked' : ''
                               }><label for="aria_mode_polite">Polite</label></p>
                               </fieldset></div>
+                            <h5 class="modal-title">LLM Settings</h5>
                               ${
                                 constants.hasChatLLM
-                                  ? '<p><input type="text" id="chatLLM_auth_key"> <label for="chatLLM_auth_key">OpenAI Authentication Key</label></p>'
+                                  ? '<p><input type="password" id="chatLLM_auth_key"> <label for="chatLLM_auth_key">OpenAI Authentication Key</label></p>'
                                   : ''
                               }
+                            <p>
+                                <select id="skill_level">
+                                    <option value="basic">Basic</option>
+                                    <option value="intermediate">Intermediate</option>
+                                    <option value="expert">Expert</option>
+                                </select>
+                                <label for="skill_level">Level of skill in statistical charts</label>
+                            </p>
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" id="save_and_close_menu">Save and close</button>
+                        <button type="button" id="save_and_close_menu">Save and Close</button>
                         <button type="button" id="close_menu">Close</button>
                     </div>
                 </div>
@@ -544,6 +554,7 @@ class Menu {
     if (typeof constants.authKey == 'string') {
       document.getElementById('chatLLM_auth_key').value = constants.authKey;
     }
+    document.getElementById('skill_level').value = constants.skillLevel;
 
     // aria mode
     if (constants.ariaMode == 'assertive') {
@@ -571,6 +582,7 @@ class Menu {
     constants.keypressInterval =
       document.getElementById('keypress_interval').value;
     constants.authKey = document.getElementById('chatLLM_auth_key').value;
+    constants.skillLevel = document.getElementById('skill_level').value;
 
     // aria
     if (document.getElementById('aria_mode_assertive').checked) {
@@ -617,6 +629,7 @@ class Menu {
     data.keypressInterval = constants.keypressInterval;
     data.ariaMode = constants.ariaMode;
     data.authKey = constants.authKey;
+    data.skillLevel = constants.skillLevel;
     localStorage.setItem('settings_data', JSON.stringify(data));
   }
   /**
@@ -635,6 +648,7 @@ class Menu {
       constants.keypressInterval = data.keypressInterval;
       constants.ariaMode = data.ariaMode;
       constants.authKey = data.authKey;
+      constants.skillLevel = data.skillLevel;
     }
     this.PopulateData();
     this.UpdateHtml();


### PR DESCRIPTION
User will set their level of skill, currently basic / intermediate / expert. The initial LLM query includes the text "Describe this chart to a blind person who has a [level of skill] level of skill in statistical charts".

closes #335 