### PR TITLE
fix: support heatmap svg with path tag

### DIFF
--- a/src/js/heatmap.js
+++ b/src/js/heatmap.js
@@ -137,8 +137,21 @@ class HeatMap {
     if (constants.hasRect) {
       for (let i = 0; i < this.plots.length; i++) {
         if (this.plots[i]) {
-          x_coord_check.push(parseFloat(this.plots[i].getAttribute('x')));
-          y_coord_check.push(parseFloat(this.plots[i].getAttribute('y')));
+          // heatmap SVG containing path element instead of rect
+          if (this.plots[i] instanceof SVGPathElement) {
+            // Assuming the path data is in the format "M x y L x y L x y L x y"
+            const path_d = this.plots[i].getAttribute('d');
+            const coords = path_d.match(/[\d\.]+/g).map(Number);
+
+            const x = coords[0];
+            const y = coords[1];
+
+            x_coord_check.push(parseFloat(x));
+            y_coord_check.push(parseFloat(y));
+          } else {
+            x_coord_check.push(parseFloat(this.plots[i].getAttribute('x')));
+            y_coord_check.push(parseFloat(this.plots[i].getAttribute('y')));
+          }
         }
       }
 


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes made in this pull request. -->
- Updated heatmap.js to highlight SVG including path elements, which are generated from Matplotlib/Seaborn

## Related Issues
<!-- Specify any related issues or tickets that this pull request addresses. -->
- Closes #342 

## Changes Made
<!-- Describe the specific changes made in this pull request. -->
- If the querySelector selects path elements, then extracted the x and y coordinates to be pushed into the heat map data 

## Screenshots (if applicable)
<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
