### PR TITLE
fix: destroy chatLLM dialog when maidr is deactivated

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -469,6 +469,9 @@ function DestroyChartComponents() {
   if (typeof description != 'undefined') {
     description.Destroy();
   }
+  if (typeof chatLLM != 'undefined') {
+    chatLLM.Destroy();
+  }
 
   constants.chart = null;
   constants.chart_container = null;


### PR DESCRIPTION
# Pull Request

## Description
This Pull request resolves the issue of multiple chatLLM dialog components being injected into HTML when maidr is activated multiple times.

## Related Issues
This Pull request resolves #520.

## Changes Made
In the `DestroyChartComponents()` function in `src/js/init.js`, we are currently not destorying the available `chatLLM` component on the HTML page. In this Pull Request, the `chatLLM` component is destroyed when all other maidr components are removed when maidr is deactivated on the plot.


## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
