### PR TITLE
fix(scatterplot): destroy highlight and cease autoplay if active on scatterplot

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -473,6 +473,15 @@ function DestroyChartComponents() {
     chatLLM.Destroy();
   }
 
+  const scatterSvg = document.querySelector('svg#scatter');
+  if (scatterSvg) {
+    // Incase autoplay was running when the highlighted plot points were being handled,
+    // kill autoplay first before removing highlight_point elements
+    constants.KillAutoplay();
+    document.querySelectorAll('.highlight_point').forEach((element) => {
+      element.remove();
+    });
+  }
   constants.chart = null;
   constants.chart_container = null;
   constants.brailleContainer = null;


### PR DESCRIPTION
# Pull Request

## Description
This Pull request is for removing highlight on plot points once maidr is deactivated. Additionally, the changes also makes sure that autoplay is killed if if active.

## Related Issues
#527 

## Changes Made
In the `DestroyChartComponents()` method in `src/js/init.js`, there is a check introduced to identify if the `svg` in the plot has an id `scatter`. Once this is confirmed, the method removes all elements with a class `highlight_point` so that all highlighted plot points are brought back to default state before maidr is deactivated.

Additionally, we preemptively kill autoplay should it be running when maidr was deactivated.

## Screenshots (if applicable)
A working demonstration of the changes in action are captured in this video
https://github.com/user-attachments/assets/ec3415e6-79be-4863-8240-8c5c44999fdc



## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
