### PR TITLE
fix(lineplot): destroy highlight and cease autoplay if active on lineplot

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -474,14 +474,22 @@ function DestroyChartComponents() {
   }
 
   const scatterSvg = document.querySelector('svg#scatter');
+  const lineSvg = document.querySelector('svg#line');
+  // Incase autoplay was running when the highlighted plot points were being handled,
+  // kill autoplay first before removing highlight_point elements
   if (scatterSvg) {
-    // Incase autoplay was running when the highlighted plot points were being handled,
-    // kill autoplay first before removing highlight_point elements
     constants.KillAutoplay();
-    document.querySelectorAll('.highlight_point').forEach((element) => {
+    scatterSvg.querySelectorAll('.highlight_point').forEach((element) => {
       element.remove();
     });
+  } else if (lineSvg) {
+    const highlightPoint = lineSvg.querySelector('#highlight_point');
+    if (highlightPoint) {
+      constants.KillAutoplay();
+      highlightPoint.remove();
+    }
   }
+
   constants.chart = null;
   constants.chart_container = null;
   constants.brailleContainer = null;


### PR DESCRIPTION
# Pull Request

## Description
This Pull request is for removing highlight on plot points once maidr is deactivated. Additionally, the changes also makes sure that autoplay is killed if if active.

## Related Issues
#529 

## Changes Made
In the `DestroyChartComponents()` method in `src/js/init.js`, there is a check introduced to identify if the svg in the plot has an id `line`. Once this is confirmed, the method removes the element with the id `highlight-point` so that all highlighted plot point is brought back to default state before maidr is deactivated.

Additionally, we preemptively kill autoplay should it be running when maidr was deactivated.

Previously, a fix for a similar issue with scatterplot had been addressed via #528 and as the codes are similar, I have performed a bit of refactoring to incorporate both changes.

## Video Demo
Here is the video demo of the lineplot example after the incorporated changes:

https://github.com/user-attachments/assets/47d0310d-5a76-45e4-bc2e-96cbb9b203b8


## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
fixes #529 
