### PR TITLE
ci: fix commitlint fails during pr merge validation

### DIFF
--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      - name: Install Dependencies
-        run: yarn install
+      - name: Install dependencies
+        run: npm install @commitlint/config-conventional @commitlint/cli
 
       - name: Lint Commit Messages
         run: npx commitlint --from=HEAD~1 --to=HEAD --verbose


### PR DESCRIPTION
# Pull Request

## Description
This PR aims to address the failure of `commitlint` job when validating commits on PR merges into main.

## Related Issues
closes #531 

## Changes Made
Earlier, the `commitlint` job was using yarn to install all dependancies required for the action's environment. The yarn installation was trying to access packages that were no longer available for download and hence, force exiting without setting up the environment.

The job uses the JavaScript based `conventional-commit` module which can be installed and managed via NPM. Hence, a new task of adding these dependancies via NPM has been added and yarn has been removed.

## Screenshots (if applicable)
Here is an excerpt from the local testing of the modified action using `netkos/act`:
```
➜  maidr git:(main) ✗ act -j commitlint
INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
WARN  ⚠ You are using Apple M-series chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'. ⚠  
WARN[0000] Could not find any stages to run. View the valid jobs with `act --list`. Use `act --help` to find how to filter by Job ID/Workflow/Event Name 
WARN[0000] Could not find any stages to run. View the valid jobs with `act --list`. Use `act --help` to find how to filter by Job ID/Workflow/Event Name 
WARN[0000] Could not find any stages to run. View the valid jobs with `act --list`. Use `act --help` to find how to filter by Job ID/Workflow/Event Name 
WARN[0000] Could not find any stages to run. View the valid jobs with `act --list`. Use `act --help` to find how to filter by Job ID/Workflow/Event Name 
[Lint Commit Messages/commitlint] 🚀  Start image=catthehacker/ubuntu:act-latest
INFO[0000] Parallel tasks (0) below minimum, setting to 1 
[Lint Commit Messages/commitlint]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[Lint Commit Messages/commitlint] using DockerAuthConfig authentication for docker pull
INFO[0001] Parallel tasks (0) below minimum, setting to 1 
[Lint Commit Messages/commitlint]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Lint Commit Messages/commitlint]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Lint Commit Messages/commitlint]   ☁  git clone 'https://github.com/actions/setup-node' # ref=v2
[Lint Commit Messages/commitlint] ⭐ Run Main Check out the repository
[Lint Commit Messages/commitlint]   🐳  docker cp src=/Users/krishnaanandan/Desktop/maidr_krishna/maidr/. dst=/Users/krishnaanandan/Desktop/maidr_krishna/maidr
[Lint Commit Messages/commitlint]   ✅  Success - Main Check out the repository
[Lint Commit Messages/commitlint] ⭐ Run Main Install Node.js
[Lint Commit Messages/commitlint]   🐳  docker cp src=/Users/krishnaanandan/.cache/act/actions-setup-node@v2/ dst=/var/run/act/actions/actions-setup-node@v2/
[Lint Commit Messages/commitlint]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-node@v2/dist/setup/index.js] user= workdir=
| Attempt to resolve LTS alias from manifest...
[Lint Commit Messages/commitlint]   💬  ::debug::Getting manifest from actions/node-versions@main
[Lint Commit Messages/commitlint]   💬  ::debug::LTS alias '*' for Node version 'lts/*'
[Lint Commit Messages/commitlint]   💬  ::debug::Found LTS release '20.17.0' for Node version 'lts/*'
[Lint Commit Messages/commitlint]   💬  ::debug::isExplicit: 
[Lint Commit Messages/commitlint]   💬  ::debug::explicit? false
[Lint Commit Messages/commitlint]   💬  ::debug::isExplicit: 20.17.0
[Lint Commit Messages/commitlint]   💬  ::debug::explicit? true
[Lint Commit Messages/commitlint]   💬  ::debug::evaluating 1 versions
[Lint Commit Messages/commitlint]   💬  ::debug::matched: 20.17.0
[Lint Commit Messages/commitlint]   💬  ::debug::checking cache: /opt/hostedtoolcache/node/20.17.0/arm64
[Lint Commit Messages/commitlint]   💬  ::debug::Found tool in cache node 20.17.0 arm64
| Found in cache @ /opt/hostedtoolcache/node/20.17.0/arm64
[Lint Commit Messages/commitlint]   ❓ add-matcher /run/act/actions/actions-setup-node@v2/.github/tsc.json
[Lint Commit Messages/commitlint]   ❓ add-matcher /run/act/actions/actions-setup-node@v2/.github/eslint-stylish.json
[Lint Commit Messages/commitlint]   ❓ add-matcher /run/act/actions/actions-setup-node@v2/.github/eslint-compact.json
[Lint Commit Messages/commitlint]   ✅  Success - Main Install Node.js
[Lint Commit Messages/commitlint]   ⚙  ::add-path:: /opt/hostedtoolcache/node/20.17.0/arm64/bin
[Lint Commit Messages/commitlint] ⭐ Run Main Install dependencies
[Lint Commit Messages/commitlint]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
| npm warn deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
| npm warn deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
| npm warn deprecated read-pkg-up@11.0.0: Renamed to read-package-up
| npm warn deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
| npm warn deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
| npm warn deprecated domexception@4.0.0: Use your platform's native DOMException instead
| npm warn deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
| npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
| npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
| npm warn deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
| npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
| npm warn deprecated @humanwhocodes/object-schema@2.0.1: Use @eslint/object-schema instead
| npm warn deprecated @humanwhocodes/config-array@0.11.13: Use @eslint/config-array instead
| npm warn deprecated glob@5.0.15: Glob versions prior to v9 are no longer supported
| 
| added 1126 packages, and audited 1362 packages in 25s
| 
| 146 packages are looking for funding
|   run `npm fund` for details
| 
| 21 vulnerabilities (1 low, 9 moderate, 11 high)
| 
| To address issues that do not require attention, run:
|   npm audit fix
| 
| To address all issues possible (including breaking changes), run:
|   npm audit fix --force
| 
| Some issues need review, and may require choosing
| a different dependency.
| 
| Run `npm audit` for details.
[Lint Commit Messages/commitlint]   ✅  Success - Main Install dependencies
[Lint Commit Messages/commitlint] ⭐ Run Main Lint Commit Messages
[Lint Commit Messages/commitlint]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
| ⧗   input: fix: cease autoplay when maidr is deactivated (outside the plot) (#526)
| ✔   found 0 problems, 0 warnings
[Lint Commit Messages/commitlint]   ✅  Success - Main Lint Commit Messages
[Lint Commit Messages/commitlint] ⭐ Run Post Install Node.js
[Lint Commit Messages/commitlint]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-node@v2/dist/cache-save/index.js] user= workdir=
[Lint Commit Messages/commitlint]   💬  ::debug::Caching for '' is not supported
[Lint Commit Messages/commitlint]   ✅  Success - Post Install Node.js
[Lint Commit Messages/commitlint] Cleaning up container for job commitlint
[Lint Commit Messages/commitlint] 🏁  Job succeeded
➜  maidr git:(main) ✗
```

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
closes #531 
