### PR TITLE
fix(heatmap): kill visual selector and autoplay post maidr teardown

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -475,6 +475,7 @@ function DestroyChartComponents() {
 
   const scatterSvg = document.querySelector('svg#scatter');
   const lineSvg = document.querySelector('svg#line');
+  const heatSvg = document.querySelector('svg#heat');
   // Incase autoplay was running when the highlighted plot points were being handled,
   // kill autoplay first before removing highlight_point elements
   if (scatterSvg) {
@@ -482,8 +483,10 @@ function DestroyChartComponents() {
     scatterSvg.querySelectorAll('.highlight_point').forEach((element) => {
       element.remove();
     });
-  } else if (lineSvg) {
-    const highlightPoint = lineSvg.querySelector('#highlight_point');
+  } else if (lineSvg || heatSvg) {
+    const highlightPoint = lineSvg
+      ? lineSvg.querySelector('#highlight_point')
+      : heatSvg.querySelector('#highlight_rect');
     if (highlightPoint) {
       constants.KillAutoplay();
       highlightPoint.remove();


### PR DESCRIPTION
# Pull Request

## Description
This Pull request contains changes to remove the visual element selector and cease autoplay when maidr is deactivated.

## Related Issues
Closes #533 

## Changes Made

As per the current teardown logic in `DestroyChartComponents()` of `src/js/init.js`, we are handling the autoplay termination  and visual element selector removal for Line plots and Scatterplots. The same has been extended to heatmap based on its configuration.

The visual element selector will be removed along with termination of autoplay on heatmap going forward. This brings the plot back to its original state and prevents maidr from autonomously running autoplay during maidr reactivation.

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
Closes #533