### PR TITLE
fix: update current active element's highlight color or fill on color change

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -1367,6 +1367,24 @@ class Menu {
       .setAttribute('aria-live', constants.ariaMode);
 
     document.getElementById('init_llm_on_load').checked = constants.autoInitLLM;
+    const scatter = document.getElementsByClassName('highlight_point');
+    const heatmap = document.getElementById('highlight_rect');
+    const line = document.getElementById('highlight_point');
+
+    if (scatter !== null && scatter.length > 0) {
+      for (let i = 0; i < scatter.length; i++) {
+        scatter[i].setAttribute('stroke', constants.colorSelected);
+        scatter[i].setAttribute('fill', constants.colorSelected);
+      }
+    }
+
+    if (heatmap !== null) {
+      heatmap.setAttribute('stroke', constants.colorSelected);
+    }
+
+    if (line !== null) {
+      line.setAttribute('stroke', constants.colorSelected);
+    }
   }
 
   /**


### PR DESCRIPTION
# Pull Request

## Description
This PR contains changes to address the issue of the current active element's highlight color when the color is modified by the user. The changes include the patches for scatterplot, lineplot and heatmap.

## Related Issues
closes #537 

## Changes Made
We have an `UpdateHTML()` method in `src/js/constants.js` which takes care of restoring aria-live mode. This function can be used to update the DOM elements, specifically in this issue, the active element on the plot. This function is being invoked when the help modal changes are saved.

Through this method, the DOM has to be manually updated by targeting the concerned elements. The changes made in this PR help to modify the `fill` or `stroke` property of the current active element on scatterplot, lineplot and heatmap depending on which attribute is used in these respective plots. The concerned attribute is updated to the last modified color.

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
Closes #537 
