### PR TITLE
fix: include retry logic for semantic-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run semantic-release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const exec = require('@actions/exec');
+            const maxRetry = 3;
+            const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+            for (let attempt = 1; attempt <= maxRetry; attempt++) {
+              try {
+                await exec.exec('yarn', ['semantic-release']);
+                break;
+              } catch (error) {
+                if (attempt < maxRetry) {
+                  console.error(`Attempt ${attempt} failed. Retrying in 60 seconds...`);
+                  await delay(60000);
+                } else {
+                  throw error;
+                }
+              }
+            }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn semantic-release
         


### PR DESCRIPTION
# Pull Request

## Description
This PR expands the scope of the semantic-release job by including a retry logic to prevent the rate limiting issue created by Github.
## Related Issues
closes #576 
## Changes Made
Instead of directly running semantic-release right after build is complete, we accommodate the possibility of being rate limited and introduce a wait interval of 60 seconds before retrying. A maximum of 3 retry attempts will be executed before terminating the semantic-release job.

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
