### PR TITLE
fix: address failure in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,12 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const exec = require('@actions/exec');
+            const { exec } = require('@actions/exec');
             const maxRetry = 3;
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
             for (let attempt = 1; attempt <= maxRetry; attempt++) {
               try {
-                await exec.exec('yarn', ['semantic-release']);
+                await exec('yarn', ['semantic-release']);
                 break;
               } catch (error) {
                 if (attempt < maxRetry) {


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses a recent failure recorded during the execution of the release action.
## Related Issues
The related failure can be found in the execution of this [run](https://github.com/xability/maidr/actions/runs/11375942426/job/31647556521)
## Changes Made
The `exec` variable has been redefined to make sure it does not cause an ambiguity with `[exec]` actions module.

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
The action was tested using netkos act locally and execution is on expected lines. As github token details are not set in my local environment, the execution could not proceed after build, yet, in the failure run, the job has failed even before beginning execution. Hence, the resolution of `exec` ambiguity has been rectified - future runs where semantic-release bot executes will be monitored to verify if the timeout helps in preventing rate-limiting.
